### PR TITLE
ADD: folderNames constants

### DIFF
--- a/src/icons/folders/c.ts
+++ b/src/icons/folders/c.ts
@@ -113,6 +113,10 @@ export const cFolders = [
     name: 'connection',
   },
   {
+    folderNames: ['constant', 'constants', 'const', 'consts', 'enum', 'enums'],
+    name: 'constants',
+  },
+  {
     folderNames: ['container', 'containers'],
     name: 'container',
   },


### PR DESCRIPTION
Issue:
The icon for the constants folder is not displaying correctly in VSCode.

<img width="123" alt="constant icon missing" src="https://github.com/user-attachments/assets/b7873918-6bb8-41fb-b130-bbe75387d6e2" />

Solution:
I noticed that the folder names for constants were missing, so I added them.

<img width="739" alt="folderNames constants" src="https://github.com/user-attachments/assets/e49286d2-b1ed-472d-9634-1015fc647bc9" />

